### PR TITLE
📝Adobe requires that all contributors sign a CLA

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,10 @@ The following are a set of guidelines to follow when contributing to this projec
 
 This project adheres to the Adobe [code of conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to Grp-opensourceoffice@adobe.com.
 
+## Contributor License Agreement
+
+All third-party contributions to this project must be accompanied by a signed contributor license agreement. This gives Adobe permission to redistribute your contributions as part of the project. Sign our [CLA](http://opensource.adobe.com/cla.html). You only need to submit an Adobe CLA one time, so if you have submitted one previously, you are good to go!
+
 ## Code Reviews
 
 All submissions should come in the form of pull requests and need to be reviewed by project committers. Read [GitHub's pull request documentation](https://help.github.com/articles/about-pull-requests/) for more information on sending pull requests.


### PR DESCRIPTION
## Overview

Adobe Legal requires that all external authors of contributions coming into Adobe projects sign an Adobe CLA: http://opensource.adobe.com/cla.html